### PR TITLE
fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # X for Y generation.
 
 ## Description
-This is a simple program which generates psuedorandom startup ideas, based on a "The X for Y" format.  Our Twitter Bot can be found here: https://twitter.com/NextBigThingBot.
+This is a simple program which generates pseudorandom startup ideas, based on a "The X for Y" format.  Our Twitter Bot can be found here: https://twitter.com/NextBigThingBot.
 
 This bot is currently hosted on [Glitch](http://glitch.com).  We use [uptimerobot](https://uptimerobot.com/) to make an http request every 12 hours to the server where this is hosted.  Every time the server gets any ping it will tweet.
 


### PR DESCRIPTION
Fixed a small typo in the README: psuedo -> pseudo